### PR TITLE
Removes further references to `Map.mean()`

### DIFF
--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1103,8 +1103,8 @@ def test_rotate(aia171_test_map):
     assert rotated_map_2.data.shape > rotated_map_1.data.shape > aia171_test_map.data.shape
     assert np.isnan(rotated_map_1.data[0, 0])
     assert np.isnan(rotated_map_2.data[0, 0])
-    np.testing.assert_allclose(aia171_test_map.data.mean(), rotated_map_1.data.mean(), rtol=5e-3)
-    np.testing.assert_allclose(aia171_test_map.data.mean(), rotated_map_2.data.mean(), rtol=5e-3)
+    np.testing.assert_allclose(aia171_test_map.data.mean(), np.nanmean(rotated_map_1.data), rtol=5e-3)
+    np.testing.assert_allclose(aia171_test_map.data.mean(), np.nanmean(rotated_map_2.data), rtol=5e-3)
 
     # A scaled-up map should have the same mean because the output map should be expanded
     rotated_map_3 = aia171_test_map.rotate(0 * u.deg, order=0, scale=2)

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -96,12 +96,12 @@ def test_all_coordinates_from_map(sub_smap):
     assert coordinates.frame.name == sub_smap.coordinate_frame.name
 
     xpix, ypix = sub_smap.wcs.world_to_pixel(coordinates[0, 0])
-    assert_quantity_allclose(xpix*u.pix, 0*u.pix, atol=1e-7*u.pix)
-    assert_quantity_allclose(ypix*u.pix, 0*u.pix, atol=1e-7*u.pix)
+    assert_quantity_allclose(xpix, 0, atol=1e-7)
+    assert_quantity_allclose(ypix, 0, atol=1e-7)
 
     xpix, ypix = sub_smap.wcs.world_to_pixel(coordinates[-1, -1])
-    assert_quantity_allclose(xpix*u.pix, sub_smap.shape[0] - 1*u.pix)
-    assert_quantity_allclose(ypix*u.pix, sub_smap.shape[1] - 1*u.pix)
+    assert_quantity_allclose(xpix, sub_smap.shape[1] - 1)
+    assert_quantity_allclose(ypix, sub_smap.shape[0] - 1)
 
 
 def test_all_corner_coordinates_from_map(sub_smap):
@@ -113,12 +113,12 @@ def test_all_corner_coordinates_from_map(sub_smap):
     assert coordinates.frame.name == sub_smap.coordinate_frame.name
 
     xpix, ypix = sub_smap.wcs.world_to_pixel(coordinates[0, 0])
-    assert_quantity_allclose(xpix*u.pix, -0.5*u.pix)
-    assert_quantity_allclose(ypix*u.pix, -0.5*u.pix)
+    assert_quantity_allclose(xpix, -0.5)
+    assert_quantity_allclose(ypix, -0.5)
 
     xpix, ypix = sub_smap.wcs.world_to_pixel(coordinates[-1, -1])
-    assert_quantity_allclose(xpix*u.pix, sub_smap.shape[0] - 0.5*u.pix)
-    assert_quantity_allclose(ypix*u.pix, sub_smap.shape[1] - 0.5*u.pix)
+    assert_quantity_allclose(xpix, sub_smap.shape[1] - 0.5)
+    assert_quantity_allclose(ypix, sub_smap.shape[0] - 0.5)
 
 
 def test_map_edges(all_off_disk_map):


### PR DESCRIPTION
bug fix with nans means in `test_rotate()`